### PR TITLE
Recreate model update issue

### DIFF
--- a/Classes/Domain/Model/ExampleModel.php
+++ b/Classes/Domain/Model/ExampleModel.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace In2code\Femanagerextended\Domain\Model;
+
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+
+class ExampleModel extends AbstractEntity
+{
+    protected $title = '';
+
+    /**
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+}

--- a/Classes/Domain/Model/User.php
+++ b/Classes/Domain/Model/User.php
@@ -18,6 +18,9 @@ class User extends \In2code\Femanager\Domain\Model\User
      */
     protected $skypeId;
 
+    /** @var ExampleModel|null $exampleModel */
+    protected ?ExampleModel $exampleModel = null;
+
     /**
      * Returns the twitterId
      *
@@ -58,5 +61,21 @@ class User extends \In2code\Femanager\Domain\Model\User
     public function setSkypeId($skypeId): void
     {
         $this->skypeId = $skypeId;
+    }
+
+    /**
+     * @return ExampleModel|null
+     */
+    public function getExampleModel(): ?ExampleModel
+    {
+        return $this->exampleModel;
+    }
+
+    /**
+     * @param ExampleModel|null $exampleModel
+     */
+    public function setExampleModel(?ExampleModel $exampleModel): void
+    {
+        $this->exampleModel = $exampleModel;
     }
 }

--- a/Configuration/PageTS/addFields.tsconfig
+++ b/Configuration/PageTS/addFields.tsconfig
@@ -1,5 +1,6 @@
 tx_femanager.flexForm.new.addFieldOptions {
   twitterId = Twitter ID
   skypeId = Skype ID
+  exampleModel = ExampleModel
 }
 tx_femanager.flexForm.edit < tx_femanager.flexForm.new

--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -30,7 +30,22 @@
                 'default' => '0',
             ],
         ],
+        'example_model' => [
+            'label' => 'Example model',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    [
+                        'None',
+                        0
+                    ]
+                ],
+                'foreign_table' => 'tx_femanagerextended_domain_model_examplemodel',
+                'default' => 0
+            ]
+        ],
     ];
 
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('fe_users', $tmpFeUsersColumns);
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('fe_users', 'twitter_id, skype_id');
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('fe_users', 'twitter_id, skype_id, example_model');

--- a/Configuration/TCA/tx_femanagerextended_domain_model_examplemodel.php
+++ b/Configuration/TCA/tx_femanagerextended_domain_model_examplemodel.php
@@ -1,0 +1,87 @@
+<?php
+
+defined('TYPO3_MODE') or die();
+
+return [
+    'ctrl' => [
+        'title' => 'Example Model',
+        'label' => 'title',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'languageField' => 'sys_language_uid',
+        'transOrigPointerField' => 'l10n_parent',
+        'transOrigDiffSourceField' => 'l10n_diffsource',
+        'translationSource' => 'l10n_source',
+        'versioningWS' => true,
+        'origUid' => 't3_origuid',
+        'default_sortby' => 'ORDER BY sorting',
+        'sortby' => 'sorting',
+        'delete' => 'deleted',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
+        'typeicon_classes' => [
+            'default' => 'ext-news-link',
+        ],
+        'hideTable' => false,
+    ],
+    'columns' => [
+        'sys_language_uid' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
+            'config' => [
+                'type' => 'language',
+            ],
+        ],
+        'l10n_parent' => [
+            'displayCond' => 'FIELD:sys_language_uid:>:0',
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['', 0],
+                ],
+                'foreign_table' => 'tx_femanagerextended_domain_model_examplemodel',
+                'foreign_table_where' => 'AND tx_femanagerextended_domain_model_examplemodel.pid=###CURRENT_PID### AND tx_femanagerextended_domain_model_examplemodel.sys_language_uid IN (-1,0)',
+                'default' => 0,
+            ],
+        ],
+        'l10n_source' => [
+            'config' => [
+                'type' => 'passthrough',
+            ],
+        ],
+        'l10n_diffsource' => [
+            'config' => [
+                'type' => 'passthrough',
+                'default' => '',
+            ],
+        ],
+        'hidden' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
+            'config' => [
+                'type' => 'check',
+                'default' => 0,
+            ],
+        ],
+        'title' => [
+            'exclude' => false,
+            'label' => 'Title',
+            'config' => [
+                'type' => 'input',
+                'size' => 30,
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ],
+            ],
+        ],
+    ],
+    'types' => [
+        0 => [
+            'showitem' => 'title',
+        ],
+    ],
+];

--- a/Resources/Private/Partials/Fields/ExampleModel.html
+++ b/Resources/Private/Partials/Fields/ExampleModel.html
@@ -1,0 +1,14 @@
+{namespace femanager=In2code\Femanager\ViewHelpers}
+<div class="femanager_fieldset femanager_examplemodel form-group">
+	<label for="femanager_field_examplemodel" class="col-sm-2 control-label">
+		Example model (no need to change any data).
+        Suspected: In2code\Femanager\Utility\ObjectUtility::implodeObjectStorageOnProperty(): Argument #1 ($objectStorage) must be of type TYPO3\CMS\Extbase\Persistence\ObjectStorage, In2code\Femanagerextended\Domain\Model\ExampleModel given, called in /var/www/html/public/typo3conf/ext/femanager/Classes/Utility/UserUtility.php on line 263
+	</label>
+	<div class="col-sm-10">
+		<femanager:form.textfield
+				id="femanager_field_examplemodel"
+				property="exampleModel"
+				class="form-control"
+				additionalAttributes="{femanager:Validation.FormValidationData(settings:settings,fieldName:'exampleModel')}" />
+	</div>
+</div>

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,0 +1,3 @@
+<?php
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_femanagerextended_domain_model_examplemodel');

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -3,5 +3,11 @@
 #
 CREATE TABLE fe_users (
 	twitter_id varchar(255) DEFAULT '' NOT NULL,
-	skype_id varchar(255) DEFAULT '' NOT NULL
+	skype_id varchar(255) DEFAULT '' NOT NULL,
+	example_model int(11) DEFAULT '0' NOT NULL
+);
+
+CREATE TABLE tx_femanagerextended_domain_model_examplemodel
+(
+	title varchar(255) DEFAULT '' NOT NULL,
 );


### PR DESCRIPTION
Example code related to https://github.com/in2code-de/femanager/issues/462

Steps:
- Update database and create at least one ExampleModel via backend list module
- In backend, attach created ExampleModel to frontend user
- Set up femanager edit plugin with only email and exampleModel fields
- While logged as previously updated user go to edit plugin and submit form.

Expected error:
```
In2code\Femanager\Utility\ObjectUtility::implodeObjectStorageOnProperty(): Argument #1 ($objectStorage) must be of type TYPO3\CMS\Extbase\Persistence\ObjectStorage, In2code\Femanagerextended\Domain\Model\ExampleModel given, called in /var/www/html/public/typo3conf/ext/femanager/Classes/Utility/UserUtility.php on line 263
```